### PR TITLE
Scanning and mac map

### DIFF
--- a/adafruit_wiz.py
+++ b/adafruit_wiz.py
@@ -149,9 +149,7 @@ def scan(radio=None, timeout=3):
         data = json.dumps({"method": "getPilot", "params": {}})
         udp_message = bytes(data, "utf-8")
 
-        scan_socket.sendto(
-            udp_message, ("255.255.255.255", 38899)
-        )  # send UDP packet to udp_host:port
+        scan_socket.sendto(udp_message, ("255.255.255.255", 38899))
         scan_complete = False
         results = []
         while not scan_complete:

--- a/examples/wiz_scan_multiple_lights.py
+++ b/examples/wiz_scan_multiple_lights.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 Tim Cocks for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+"""
+Scan the network for Wiz lights. Print out the MAC addresses of any lights found.
+Set each light to a different random RGB color.
+"""
+
+import random
+
+import wifi
+
+from adafruit_wiz import WizConnectedLight, scan
+
+udp_port = 38899  # Default port is 38899
+colors = [(255, 0, 0), (0, 255, 0), (0, 0, 255), (255, 255, 0), (0, 255, 255), (255, 0, 255)]
+mac_to_light_map = {}
+
+found_lights = scan(wifi.radio, timeout=1)
+for light_info in found_lights:
+    mac_to_light_map[light_info["result"]["mac"]] = WizConnectedLight(
+        light_info["ip"], udp_port, wifi.radio
+    )
+    print(f"Found Light with MAC: {light_info['result']['mac']}")
+
+for mac, light in mac_to_light_map.items():
+    chosen_color = random.choice(colors)
+    print(f"Setting light with MAC: {mac} to {chosen_color}")
+    light.rgb_color = chosen_color


### PR DESCRIPTION
@ladyada 

Implements a new `scan()` function at the module level that uses UDP multicast to find all active lights on the network and return the info about them.

A new example uses this function to find multiple lights and build a mapping between mac address and light instance, then loop over them and set each to a random color.